### PR TITLE
Update license to work with a Creative Commons Attribution license

### DIFF
--- a/youtube/video.py
+++ b/youtube/video.py
@@ -219,7 +219,7 @@ class VideoInfoExtractor(object):
         return re.search(r'"genre" content="(.*)"', self.html).group(1)
 
     def license(self):
-        return re.search(r'Standard YouTube License|Creative Commons - Attribution',
+        return re.search(r'Standard YouTube License|Creative Commons Attribution',
                          self.html).group()
 
     def keywords(self):


### PR DESCRIPTION
I thought I had created a PR for this against the original repo from @Fallmay, but I guess I didn't. This PR fixes parsing the license when a video actually has a Creative Commons Attribution license, because what's in the documentation and what's on the video pages is different.